### PR TITLE
Update of Node version from 8 to 10

### DIFF
--- a/cloud-functions-start/functions/package.json
+++ b/cloud-functions-start/functions/package.json
@@ -10,7 +10,7 @@
     "eslint-plugin-promise": "^3.6.0"
   },
   "engines": {
-    "node": "8"
+    "node": "10"
   },
   "private": true
 }


### PR DESCRIPTION
Following the Codelab tutorial throws an error when you try to deploy the given functions due to the usage of a deprecated node version.