### PR TITLE
Node.js 8 functions are deprecated

### DIFF
--- a/cloud-functions-start/functions/package.json
+++ b/cloud-functions-start/functions/package.json
@@ -10,7 +10,7 @@
     "eslint-plugin-promise": "^3.6.0"
   },
   "engines": {
-    "node": "8"
+    "node": "12"
   },
   "private": true
 }


### PR DESCRIPTION
Node.js 8 functions are deprecated and it has to be upgraded to minimum 10 or greater.
As stated by [firebase documentation](https://firebase.google.com/docs/functions/manage-functions). Node.js 12 functions are more stable version also successful for this repository.