### PR TITLE
Update Node engine to a supported GCF version

### DIFF
--- a/cloud-functions/functions/package.json
+++ b/cloud-functions/functions/package.json
@@ -12,7 +12,7 @@
     "eslint-plugin-promise": "^3.6.0"
   },
   "engines": {
-    "node": "8"
+    "node": "12"
   },
   "private": true
 }

--- a/web-start/functions/package.json
+++ b/web-start/functions/package.json
@@ -10,7 +10,7 @@
     "eslint-plugin-promise": "^3.6.0"
   },
   "engines": {
-    "node": "8"
+    "node": "12"
   },
   "private": true
 }

--- a/web/functions/package.json
+++ b/web/functions/package.json
@@ -10,7 +10,7 @@
     "eslint-plugin-promise": "^3.6.0"
   },
   "engines": {
-    "node": "8"
+    "node": "12"
   },
   "private": true
 }


### PR DESCRIPTION
There are three cases where the node version was still on 8, which isn't allowed to be deployed anymore. Updated to be 12, the version used elsewhere in the project.