### PR TITLE
Add MFA enrollment and sign in

### DIFF
--- a/web/public/index.html
+++ b/web/public/index.html
@@ -93,7 +93,6 @@
         </form>
 
         <!-- Select second factor for MFA accounts -->
-       
         <h5 hidden id="select-second-factor-text">Select second factor to complete sign-in</h5>
         <button hidden id="select-second-factor-button" class="mdl-button mdl-js-button mdl-button--icon">
           <i class="material-icons">arrow_drop_down</i>

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -70,6 +70,52 @@
         <button hidden id="sign-in" class="mdl-button mdl-js-button mdl-js-ripple-effect mdl-color-text--white">
           <i class="material-icons">account_circle</i>Sign-in with Google
         </button>
+
+        <!-- Panel to enroll in MFA -->
+        <button hidden id="user-settings" class="mdl-button mdl-js-button mdl-button--icon">
+          <i class="material-icons">more_vert</i>
+        </button>
+        <ul id="user-settings-drop-down" class="mdl-menu mdl-menu--bottom-right mdl-js-menu mdl-js-ripple-effect" for="user-settings">
+          <li id="start-enroll-second-factor" class="mdl-menu__item">Enroll a second factor</li>
+        </ul>
+
+        <!-- Enter phone number to enroll as a second factor. -->
+        <form hidden id="enroll-second-factor-form" action="#">
+          <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+            <input class="mdl-textfield__input" type="text" id="phone-number" autocomplete="off">
+            <label class="mdl-textfield__label" for="phone-number">Phone number</label>
+          </div>
+          <button id="enroll-second-factor-submit" type="submit" class="mfa-submit mdl-color--grey-100 mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect">
+            Enroll as second factor
+          </button>
+          <!-- Invisible reCAPTCHA -->
+          <div id="recaptcha"></div>
+        </form>
+
+        <!-- Select second factor for MFA accounts -->
+       
+        <h5 hidden id="select-second-factor-text">Select second factor to complete sign-in</h5>
+        <button hidden id="select-second-factor-button" class="mdl-button mdl-js-button mdl-button--icon">
+          <i class="material-icons">arrow_drop_down</i>
+        </button>
+        <div hidden id="select-second-factor">
+          <ul id="select-second-factor-drop-down" class="mdl-menu mdl-menu--bottom-right mdl-js-menu mdl-js-ripple-effect" for="select-second-factor-button">
+          </ul>
+        </div>
+
+        <!-- Enter verification code to complete sign-in for or enrollment of MFA accounts -->
+        <form hidden id="verification-code-form" action="#">
+          <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+            <input class="mdl-textfield__input" type="text" id="verification-code" autocomplete="off">
+            <label class="mdl-textfield__label" for="verification-code">Verification code</label>
+          </div>
+          <button hidden id="enroll-verification-code-submit" type="submit" class="mfa-submit mdl-color--grey-100 mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect">
+            Finish enrollment
+          </button>
+          <button hidden id="verification-code-submit" type="submit" class="mfa-submit mdl-color--grey-100 mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect">
+            Finish sign-in
+          </button>
+        </form>
       </div>
     </div>
   </header>

--- a/web/public/styles/main.css
+++ b/web/public/styles/main.css
@@ -199,3 +199,17 @@ main, #messages-card {
   top: -1px;
   margin-right: 5px;
 }
+#select-second-factor-button.mdl-button .material-icons, #user-settings.mdl-button .material-icons {
+  top: 50%;
+  left: 10px;
+}
+#select-second-factor-text {
+  margin: 0px;
+  position: relative;
+  top: 8px;
+  right: 8px;
+}
+.mfa-submit {
+  margin-left: 10px;
+  margin-bottom: 10px;
+}

--- a/web/src/index.js
+++ b/web/src/index.js
@@ -23,6 +23,11 @@ import {
   signInWithPopup,
   signOut,
   connectAuthEmulator,
+  getMultiFactorResolver,
+  multiFactor,
+  PhoneAuthProvider,
+  PhoneMultiFactorGenerator,
+  RecaptchaVerifier,
 } from "firebase/auth";
 import {
   getFirestore,
@@ -50,11 +55,161 @@ import { getFunctions, connectFunctionsEmulator } from "firebase/functions";
 
 import { getFirebaseConfig } from "./firebase-config.js";
 
+// Used in multi-factor sign in flow.
+var multiFactorResolver = null;
+
 // Signs-in Friendly Chat.
 async function signIn() {
   // Sign in Firebase using popup auth and Google as the identity provider.
   var provider = new GoogleAuthProvider();
-  await signInWithPopup(getAuth(), provider);
+  await signInWithPopup(getAuth(), provider)
+    .then(function (userCredential) {
+      // User successfully signed in and is not enrolled with a second factor.
+    })
+    .catch(function (error) {
+      if (error.code == "auth/multi-factor-auth-required") {
+        // The user is a multi-factor user. Second factor challenge is required.
+        multiFactorResolver = getMultiFactorResolver(getAuth(), error);
+        displaySecondFactor(multiFactorResolver.hints);
+      } else {
+        console.error("Error signing in user", error);
+      }
+    });
+}
+
+// Display second factor options for current user.
+function displaySecondFactor(multiFactorInfoHints) {
+  for (var i = 0; i < multiFactorInfoHints.length; i++) {
+    const hint = multiFactorInfoHints[i];
+
+    // Create element
+    const selection = document.createElement("li");
+    selection.textContent = hint.displayName
+      ? `${hint.displayName} - ${hint.phoneNumber}`
+      : hint.phoneNumber;
+    selection.classList.add("mdl-menu__item");
+
+    // Add event listener for each selection
+    selection.addEventListener("click", onSelectSecondFactor);
+
+    // Add to second factor drop down menu
+    selectSecondFactorDropDownElement.appendChild(selection);
+  }
+
+  signInButtonElement.setAttribute("hidden", "true");
+
+  selectSecondFactorTextElement.removeAttribute("hidden");
+  selectSecondFactorButtonElement.removeAttribute("hidden");
+  selectSecondFactorElement.removeAttribute("hidden");
+}
+
+// TODO: split up logic from display logic
+async function onSelectSecondFactor(e) {
+  e.preventDefault();
+
+  const selectedIndex = Array.prototype.indexOf.call(
+    selectSecondFactorDropDownElement.children,
+    e.target
+  );
+  
+  if (
+    multiFactorResolver.hints[selectedIndex].factorId ===
+    PhoneMultiFactorGenerator.FACTOR_ID
+  ) {
+    const recaptchaVerifier = new RecaptchaVerifier(
+      "recaptcha",
+      { size: "invisible" },
+      getAuth()
+    );
+    const phoneInfoOptions = {
+      multiFactorHint: multiFactorResolver.hints[selectedIndex],
+      session: multiFactorResolver.session,
+    };
+    const phoneAuthProvider = new PhoneAuthProvider(getAuth());
+    // Send SMS verification code
+    verificationId = await phoneAuthProvider.verifyPhoneNumber(
+      phoneInfoOptions,
+      recaptchaVerifier
+    );
+
+    // Hide selection panel
+    selectSecondFactorTextElement.setAttribute("hidden", "true");
+    selectSecondFactorButtonElement.setAttribute("hidden", "true");
+    selectSecondFactorElement.setAttribute("hidden", "true");
+
+    // Display verification code form
+    verificationCodeFormElement.removeAttribute("hidden");
+    verificationCodeSubmitButtonElement.removeAttribute("hidden");
+
+    // Clear list for future sign in's
+    while (selectSecondFactorDropDownElement.lastElementChild) {
+      selectSecondFactorDropDownElement.removeChild(
+        selectSecondFactorDropDownElement.lastElementChild
+      );
+    }
+  } else {
+    console.error("Only phone number second factors are supported");
+  }
+}
+
+async function finishSecondFactorSignIn(verificationCode) {
+  // Get SMS verification code sent to user.
+  const cred = PhoneAuthProvider.credential(verificationId, verificationCode);
+  const multiFactorAssertion = PhoneMultiFactorGenerator.assertion(cred);
+
+  // Complete sign-in.
+  await multiFactorResolver.resolveSignIn(multiFactorAssertion);
+
+  verificationId = null;
+}
+
+// Used in multi-factor enrollment flow.
+var verificationId = null;
+
+// Enrolls a phone number for second factor sign in
+async function enrollMultiFactor(phoneNumber) {
+  const recaptchaVerifier = new RecaptchaVerifier(
+    "recaptcha",
+    { size: "invisible" },
+    getAuth()
+  );
+
+  verificationId = await multiFactor(getAuth().currentUser)
+    .getSession()
+    .then(function (multiFactorSession) {
+      // Specify the phone number and pass the MFA session.
+      const phoneInfoOptions = {
+        phoneNumber: phoneNumber,
+        session: multiFactorSession,
+      };
+
+      const phoneAuthProvider = new PhoneAuthProvider(getAuth());
+
+      // Send SMS verification code.
+      return phoneAuthProvider.verifyPhoneNumber(
+        phoneInfoOptions,
+        recaptchaVerifier
+      );
+    })
+    .catch(function (error) {
+      console.log("Error enrolling second factor", error);
+    });
+}
+
+// TODO: rename, add back in display name
+async function finishEnrollMultiFactor(
+  verificationCode
+  // mfaDisplayName = "display name"
+) {
+  // Ask user for the verification code. Then:
+  const cred = PhoneAuthProvider.credential(verificationId, verificationCode);
+  const multiFactorAssertion = PhoneMultiFactorGenerator.assertion(cred);
+
+  // Complete enrollment.
+  await multiFactor(getAuth().currentUser).enroll(
+    multiFactorAssertion /* , mfaDisplayName */
+  );
+  verificationId = null;
 }
 
 // Signs-out of Friendly Chat.
@@ -240,6 +395,63 @@ function onMessageFormSubmit(e) {
   }
 }
 
+// Triggers MFA enrollment flow.
+function displayMfaEnrollment(e) {
+  e.preventDefault();
+
+  userSettingsButtonElement.setAttribute("hidden", "true");
+  signOutButtonElement.setAttribute("hidden", "true");
+
+  enrollSecondFactorFormElement.removeAttribute("hidden");
+}
+
+function startMfaEnrollment(e) {
+  e.preventDefault();
+
+  // Check that the user entered a phone number.
+  if (phoneNumberElement.value) {
+    // TODO: display message when phone number is not well formatted
+    enrollMultiFactor(phoneNumberElement.value);
+
+    enrollSecondFactorFormElement.reset();
+    enrollSecondFactorFormElement.setAttribute("hidden", "true");
+    verificationCodeFormElement.removeAttribute("hidden");
+    enrollVerificationCodeSubmitButtonElement.removeAttribute("hidden");
+  }
+}
+
+function finishMfaEnrollment(e) {
+  e.preventDefault();
+
+  // Check that the user entered a verification number.
+  if (verificationCodeElement.value) {
+    finishEnrollMultiFactor(verificationCodeElement.value);
+
+    verificationCodeFormElement.reset();
+    verificationCodeFormElement.setAttribute("hidden", "true");
+    enrollVerificationCodeSubmitButtonElement.setAttribute("hidden", "true");
+
+    userSettingsButtonElement.removeAttribute("hidden");
+    signOutButtonElement.removeAttribute("hidden");
+  }
+}
+
+function finishMfaSignIn(e) {
+  e.preventDefault();
+
+  // Check that the user entered a verification number.
+  if (verificationCodeElement.value) {
+    finishSecondFactorSignIn(verificationCodeElement.value);
+
+    verificationCodeFormElement.reset();
+    verificationCodeFormElement.setAttribute("hidden", "true");
+    verificationCodeSubmitButtonElement.setAttribute("hidden", "true");
+
+    userSettingsButtonElement.removeAttribute("hidden");
+    signOutButtonElement.removeAttribute("hidden");
+  }
+}
+
 // Triggers when the auth state change for instance when the user signs-in or signs-out.
 function authStateObserver(user) {
   if (user) {
@@ -261,6 +473,9 @@ function authStateObserver(user) {
     // Hide sign-in buttons.
     signInButtonElement.setAttribute("hidden", "true");
 
+    // Display user settings hamburger button.
+    userSettingsButtonElement.removeAttribute("hidden");
+
     // We save the Firebase Messaging Device token and enable notifications.
     saveMessagingDeviceToken();
   } else {
@@ -269,6 +484,9 @@ function authStateObserver(user) {
     userNameElement.setAttribute("hidden", "true");
     userPicElement.setAttribute("hidden", "true");
     signOutButtonElement.setAttribute("hidden", "true");
+
+    // Hide user settings hamburger button.
+    userSettingsButtonElement.setAttribute("hidden", "true");
 
     // Show sign-in buttons.
     signInButtonElement.removeAttribute("hidden");
@@ -425,6 +643,37 @@ var userNameElement = document.getElementById("user-name");
 var signInButtonElement = document.getElementById("sign-in");
 var signOutButtonElement = document.getElementById("sign-out");
 var signInSnackbarElement = document.getElementById("must-signin-snackbar");
+var userSettingsButtonElement = document.getElementById("user-settings");
+var startEnrollSecondFactorElement = document.getElementById(
+  "start-enroll-second-factor"
+);
+var phoneNumberElement = document.getElementById("phone-number");
+var enrollSecondFactorFormElement = document.getElementById(
+  "enroll-second-factor-form"
+);
+var enrollSecondFactorSubmitButtonElement = document.getElementById(
+  "enroll-second-factor-submit"
+);
+var selectSecondFactorTextElement = document.getElementById(
+  "select-second-factor-text"
+);
+var selectSecondFactorButtonElement = document.getElementById(
+  "select-second-factor-button"
+);
+const selectSecondFactorElement = document.getElementById("select-second-factor");
+var selectSecondFactorDropDownElement = document.getElementById(
+  "select-second-factor-drop-down"
+);
+var verificationCodeFormElement = document.getElementById(
+  "verification-code-form"
+);
+var verificationCodeElement = document.getElementById("verification-code");
+var enrollVerificationCodeSubmitButtonElement = document.getElementById(
+  "enroll-verification-code-submit"
+);
+var verificationCodeSubmitButtonElement = document.getElementById(
+  "verification-code-submit"
+);
 
 // Saves message on form submit.
 messageFormElement.addEventListener("submit", onMessageFormSubmit);
@@ -432,6 +681,18 @@ messageFormElement.addEventListener("submit", onMessageFormSubmit);
 // Buttons for sign in and sign out.
 signOutButtonElement.addEventListener("click", signOutUser);
 signInButtonElement.addEventListener("click", signIn);
+
+// Buttons for MFA flows.
+startEnrollSecondFactorElement.addEventListener("click", displayMfaEnrollment);
+enrollSecondFactorSubmitButtonElement.addEventListener(
+  "click",
+  startMfaEnrollment
+);
+enrollVerificationCodeSubmitButtonElement.addEventListener(
+  "click",
+  finishMfaEnrollment
+);
+verificationCodeSubmitButtonElement.addEventListener("click", finishMfaSignIn);
 
 // Toggle for the button.
 messageInputElement.addEventListener("keyup", toggleButton);


### PR DESCRIPTION
Adds MFA enrollment and second factor sign in to friendly chat. Allows users to register multiple phone numbers for MFA. See following for demo videos:
- [go/codelab-friendlychat-web-680-mfa](http://go/codelab-friendlychat-web-680-mfa) - "happy case" for enrollment and sign in
- ~[go/codelab-friendlychat-web-680-edge-case](http://go/codelab-friendlychat-web-680-edge-case) - edge cases for enrollment and sign in (thrown in console since snackbar is hidden by emulator banner)~
- [go/codelab-friendlychat-web-680-alert](http://go/codelab-friendlychat-web-680-alert) - updated edge case handling using alerts for more visibility

Note: I feel very so-so about the UI right now, I'm open to any suggestions